### PR TITLE
TOOLS-2555 Jenkins agents need openjdk11

### DIFF
--- a/tools/validate-buildenv.sh
+++ b/tools/validate-buildenv.sh
@@ -7,7 +7,7 @@
 
 #
 # Copyright 2022 Joyent, Inc.
-# Copyright 2022 MNX Cloud, Inc.
+# Copyright 2023 MNX Cloud, Inc.
 #
 
 #
@@ -555,7 +555,7 @@ function validate_opt_tools {
             git-base
             git-docs
             git-contrib
-            openjdk8
+            openjdk11
             nodejs-8.17.0nb1
             npm
             gcc7


### PR DESCRIPTION
Now that Jenkins requires Java 11, we need to check for that instead of Java 8.